### PR TITLE
Update sources.list template for usage with bullseye and bookworm

### DIFF
--- a/templates/apt/sources.list.j2
+++ b/templates/apt/sources.list.j2
@@ -4,4 +4,8 @@ deb {{ base_debian_mirror }} {{ ansible_distribution_release }} main contrib non
 {% if ansible_distribution_release != 'jessie' and base_enable_backports %}
 deb {{ base_debian_mirror }} {{ ansible_distribution_release }}-backports main contrib non-free
 {% endif %}
+{% if ansible_distribution_release == 'bullseye' or ansible_distribution_release == 'bookworm' %}
+deb http://security.debian.org/debian-security {{ ansible_distribution_release }}-security main contrib non-free
+{% else %}
 deb http://security.debian.org {{ ansible_distribution_release }}/updates main contrib non-free
+{% endif %}


### PR DESCRIPTION
Use new security.debian.org repository layout for bullseye (Debian v11) and bookworm (v12).

Quoting from https://lists.debian.org/debian-devel-announce/2019/07/msg00004.html:

| over the last years we had people getting confused over <suite>-updates
| (recommended updates) and <suite>/updates (security updates).  Starting
| with Debian 11 "bullseye" we have therefore renamed the suite including
| the security updates to <suite>-security.
|
| An entry in sources.list should look like
|
|   deb http://security.debian.org/debian-security bullseye-security main
|
| For previous releases the name will not change.