### PR TITLE
ansible_facts.d/services.fact: support mariadbd on Debian/bullseye and newer

### DIFF
--- a/files/ansible_facts.d/services.fact
+++ b/files/ansible_facts.d/services.fact
@@ -2,7 +2,9 @@
 # HEADER: managed by ansible, do NOT edit manually!
 
 MYSQL_STATE=false
-pgrep mysqld >/dev/null 2>&1 && MYSQL_STATE=true
+if pgrep mysqld >/dev/null 2>&1 || pgrep mariadbd >/dev/null 2>&1 ; then
+  MYSQL_STATE=true
+fi
 
 APACHE_STATE=false
 pgrep -f /usr/sbin/apache2 >/dev/null 2>&1 && APACHE_STATE=true


### PR DESCRIPTION
Starting with Debian/bullseye, mariadb-server no longer runs
as /usr/sbin/mysqld, but as /usr/sbin/mariadbd. Adjust
the fact check accordingly.