### PR TITLE
Only install ntp package if variable base_ntp_client is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,63 @@ Default Role Variables
 base_debian_mirror: http://deb.debian.org/debian
 # If the Debian distribution is not jessie, 'backports' are enabled by default
 base_enable_backports: True
-
+# Set the ntp package to be installed (e.g. chrony or systemd-timesyncd)
+# If no ntp package should be installed set an empty string (base_ntp_package: '')
+base_ntp_package: "ntp"
 ```
 
 Dependencies
 ------------
 
 None.
+
+Notes on NTP
+------------
+
+Non-default / local time servers are (currently) not supported by this role.
+
+For `systemd-timesyncd` it is `/etc/systemd/timesyncd.conf`:
+```ini
+[Time]
+NTP=ntp1.example.com ntp2.example.com ntp3.example.com ntp4.example.com
+```
+
+For `ntp` it is `/etc/ntp.conf`:
+```text
+pool time.example.com iburst
+```
+
+or
+
+```text
+server time.example.com iburst
+```
+
+We use iburst by default. I think this is OK. From ntp.conf(5):
+
+  > iburst: When the server is unreachable, send a burst of six packets instead of the usual one. The packet spacing is normally 2 s; [...]
+
+Use server instead of pool if no round-robin DNS is involved, though.
+
+For `chrony` it is `/etc/chrony.conf`:
+
+```text
+server time.example.com prefer iburst
+
+# Allow NTP client access from local network.
+# allow 192.168.7.0/24
+```
+
+Which NTP Daemon?
+
+We should favor `chrony` over `ntp` (from [Choosing Between NTP Daemons](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/system_administrators_guide#sect-Choosing_between_NTP_daemon)):
+
+  > Chrony should be preferred for all systems except for the systems that are managed or monitored by tools that do not support chrony, or the systems that have a hardware reference clock which cannot be used with chrony.
+
+Further reading:
+
+* [Differences Between ntpd and chronyd](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/system_administrators_guide/index#sect-differences_between_ntpd_and_chronyd)
+* [Comparison of NTP implementations](https://chrony.tuxfamily.org/comparison.html)
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,6 @@
 base_debian_mirror: http://deb.debian.org/debian
 # Debian backports are disabled by default
 base_enable_backports: false
+# Set the ntp package to be installed (e.g. chrony or systemd-timesyncd)
+# If no ntp package should be installed set an empty string (base_ntp_package: '')
+base_ntp_package: "ntp"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,7 @@
   notify: apt-get update
   when: ansible_distribution == 'Debian'
 - meta: flush_handlers
+
 - name: Ensure base Debian package selection is installed
   apt:
     name:
@@ -34,7 +35,6 @@
       - needrestart
       # Do not install, because proxmox conflicts with this package
       # - netcat-openbsd
-      - ntp
       - parted
       - psmisc
       - screen
@@ -51,6 +51,15 @@
       - apt-transport-https
     state: present
   when: ansible_distribution_release == 'stretch'
+
+- name: Install ntp client / daemon
+  apt:
+    name:
+      - "{{ base_ntp_package }}"
+    state: present
+  when:
+    - base_ntp_package is defined
+    - base_ntp_package | length > 0
 
 - name: Ensure extended base Debian package selection is installed (for VMs)
   apt:


### PR DESCRIPTION
Sometimes there is a need to install a different ntp package.
To change the package the variable base_ntp_client needs to be set.
To avoid that no ntp client is installed, we still default to the ntp
package. This might change in the future.

Thanks @mika for the report.

Closes: jkirk/ansible-role-base#7