### PR TITLE
WIP: Update default molecule scenario + fix verify 

### DIFF
--- a/molecule/default/Dockerfile_debian_bullseye.j2
+++ b/molecule/default/Dockerfile_debian_bullseye.j2
@@ -1,0 +1,48 @@
+FROM docker.io/debian:bullseye-slim
+
+LABEL org.opencontainers.image.description="Debian 11 Container for Molecule"
+LABEL org.opencontainers.image.source=https://gitlab.com/aussielunix/ansible/molecule-containers
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Avoid apt warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends systemd systemd-sysv \
+    sudo procps python3-pip python3-dev python3-setuptools python3-wheel  \
+    # Clean up
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean
+
+# Create `ansible` user and group with sudo permissions
+RUN set -xe \
+  && useradd -m -U -G sudo -s /bin/bash ansible \
+  && sed -i "/^%sudo/s/ALL\$/NOPASSWD:ALL/g" /etc/sudoers
+
+# Upgrade pip to latest version to avoid wheel / cryptography issues
+RUN pip3 install --upgrade pip
+
+# Install Ansible via pip.
+RUN pip3 install ansible-core ansible-lint cryptography
+
+# Install Ansible inventory file.
+RUN mkdir -p /etc/ansible
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+    /etc/systemd/system/*.wants/* \
+    /lib/systemd/system/local-fs.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl* \
+    /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
+    /lib/systemd/system/systemd-update-utmp*
+
+CMD [ "/lib/systemd/systemd", "log-level=info", "unit=sysinit.target" ]

--- a/molecule/default/Dockerfile_debian_buster.j2
+++ b/molecule/default/Dockerfile_debian_buster.j2
@@ -1,0 +1,48 @@
+FROM docker.io/debian:buster-slim
+
+LABEL org.opencontainers.image.description="Debian 10 Container for Molecule"
+LABEL org.opencontainers.image.source=https://gitlab.com/aussielunix/ansible/molecule-containers
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Avoid apt warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends systemd systemd-sysv \
+    sudo procps python3-pip python3-dev python3-setuptools python3-wheel  \
+    # Clean up
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean
+
+# Create `ansible` user and group with sudo permissions
+RUN set -xe \
+  && useradd -m -U -G sudo -s /bin/bash ansible \
+  && sed -i "/^%sudo/s/ALL\$/NOPASSWD:ALL/g" /etc/sudoers
+
+# Upgrade pip to latest version to avoid wheel / cryptography issues
+RUN pip3 install --upgrade pip
+
+# Install Ansible via pip.
+RUN pip3 install ansible-core ansible-lint cryptography
+
+# Install Ansible inventory file.
+RUN mkdir -p /etc/ansible
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+    /etc/systemd/system/*.wants/* \
+    /lib/systemd/system/local-fs.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl* \
+    /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
+    /lib/systemd/system/systemd-update-utmp*
+
+CMD [ "/lib/systemd/systemd", "log-level=info", "unit=sysinit.target" ]

--- a/molecule/default/files/chrony.bullseye.example.conf
+++ b/molecule/default/files/chrony.bullseye.example.conf
@@ -47,7 +47,7 @@ makestep 1 3
 # leap-smeared time.
 leapsectz right/UTC
 
-# Allow NTP client access from given network
+# Allow NTP client access from given network(s)
 allow 127/8
 #
 # Set NTP server which can be used as a time source (server),

--- a/molecule/default/files/chrony.buster.example.conf
+++ b/molecule/default/files/chrony.buster.example.conf
@@ -28,7 +28,7 @@ rtcsync
 # one second, but only in the first three clock updates.
 makestep 1 3
 
-# Allow NTP client access from given network
+# Allow NTP client access from given network(s)
 allow 127/8
 #
 # Set NTP server which can be used as a time source (server),

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,19 +5,23 @@ driver:
   name: docker
 platforms:
   - name: debian10
-    image: geerlingguy/docker-debian10-ansible
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    image: docker.io/debian:buster-slim
+    dockerfile: Dockerfile_debian_buster.j2
     privileged: true
-    pre_build_image: true
+    pre_build_image: false
+    override_command: false
+    tmpfs:
+      - /run
+      - /tmp
   - name: debian11
-    image: geerlingguy/docker-debian11-ansible
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    image: docker.io/debian:bullseye-slim
+    dockerfile: Dockerfile_debian_bullseye.j2
     privileged: true
-    pre_build_image: true
+    pre_build_image: false
+    override_command: false
+    tmpfs:
+      - /run
+      - /tmp
 provisioner:
   name: ansible
 verifier:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,7 +3,7 @@
 
 - name: Verify
   hosts: all
-  gather_facts: false
+  gather_facts: true
   tasks:
   - name: Deploy chrony with server configuration
     copy:


### PR DESCRIPTION
`molecule test` works locally, but fails for Debian/bullseye in the Github Action:
```
  TASK [ansible-role-base : Make sure ntp service is started] ********************
  fatal: [debian11]: FAILED! => {"changed": false, "msg": "Unable to start service chrony: Job for chrony.service failed because the control process exited with error code.\nSee \"systemctl status chrony.service\" and \"journalctl -xe\" for details.\n"}
  changed: [debian10]
```

Also see: geerlingguy/docker-debian11-ansible#4