### PR TITLE
Debian: fix non-free-firmware usage in sources.list

### DIFF
--- a/templates/apt/sources.list.j2
+++ b/templates/apt/sources.list.j2
@@ -64,10 +64,10 @@ deb https://security.debian.org/debian-security {{ ansible_distribution_release 
 {% if base_enable_stable_updates %}
 {% if ansible_distribution_release == 'bullseye' %}
 # NOTE: EOL since 2024-08-14 (main), currently covered by LTS (until 2026-08-31) + ELTS (until 2031-06-30)
-deb {{ base_debian_mirror }} bullseye-updates main contrib non-free-firmware
+deb {{ base_debian_mirror }} bullseye-updates main contrib non-free
 {% elif ansible_distribution_release == 'bookworm' %}
 # NOTE: supported until 2026-06-10 (main), 2028-06-30 (LTS) + 2033-06-30 (ELTS)
-deb {{ base_debian_mirror }} bookworm-updates main contrib non-free
+deb {{ base_debian_mirror }} bookworm-updates main contrib non-free-firmware
 {% endif %}{# ansible_distribution_release == 'bullseye' #}
 {% endif %}{# base_enable_stable_updates #}
 {% if base_enable_elts %}


### PR DESCRIPTION
The non-free-firmware component is provided only as of bookworm. Usage of non-free-firmware for bullseye-updates is obviously wrong, instead it should have been placed at bookworm-updates.

Followup fix for git commit 1b83227fd7aa1378ebbd8fcebef51eb22a3b317a