### PR TITLE
Add lsof, most + strace to base Debian package selection

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,7 @@
       - lsof
       - man-db
       - moreutils
+      - most
       - needrestart
       - netcat-openbsd
       - parted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,7 @@
       - rsync
       - screen
       - socat
+      - strace
       - tmux
       - unzip
       - vim

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
       - iotop
       - jq
       - ldnsutils
+      - lsof
       - man-db
       - moreutils
       - needrestart


### PR DESCRIPTION
Identified this in the delate of our grml-debootstrap vs. cloud-init systems.