### PR TITLE
Debian: update /etc/apt/sources.list template for recent changes in Debian

### DIFF
--- a/templates/apt/sources.list.j2
+++ b/templates/apt/sources.list.j2
@@ -4,7 +4,7 @@
 # WARN: EOL since 2016-04-25 (main), 2018-05-31 (LTS) + 2020-06-30 (ELTS)
 deb http://archive.debian.org/debian wheezy main contrib non-free
 {% elif ansible_distribution_release == 'jessie' %}
-# NOTE: EOL since 2018-06-17 (main), 2020-06-30 (LTS), currently covered only by ELTS (until 2025-06-30)
+# WARN: EOL since 2018-06-17 (main), 2020-06-30 (LTS) + 2025-06-30 (ELTS)
 deb http://archive.debian.org/debian jessie main contrib non-free
 {% elif ansible_distribution_release == 'stretch' %}
 # NOTE: EOL since 2020-07-18 (main), 2022-07-01 (LTS), currently covered only by ELTS (until 2027-06-30)
@@ -44,7 +44,7 @@ deb {{ base_debian_mirror }} {{ ansible_distribution_release }}-backports main c
 # WARN: EOL since 2016-04-25 (main), 2018-05-31 (LTS) + 2020-06-30 (ELTS)
 deb http://archive.debian.org/debian-security/ wheezy/updates main contrib non-free
 {% elif ansible_distribution_release == 'jessie' %}
-# NOTE: EOL since 2018-06-17 (main), 2020-06-30 (LTS), currently covered only by ELTS (until 2025-06-30)
+# WARN: EOL since 2018-06-17 (main), 2020-06-30 (LTS) + 2025-06-30 (ELTS)
 deb http://archive.debian.org/debian-security jessie/updates main contrib non-free
 {% elif ansible_distribution_release == 'stretch' %}
 # NOTE: EOL since 2020-07-18 (main), 2022-07-01 (LTS), currently covered only by ELTS (until 2027-06-30)
@@ -75,7 +75,7 @@ deb {{ base_debian_mirror }} bookworm-updates main contrib non-free-firmware
 # WARN: Extended Long Term Support - EOL since 2020-06-30 (see https://wiki.debian.org/LTS/Extended)
 deb https://deb.freexian.com/extended-lts wheezy-lts main contrib non-free
 {% elif ansible_distribution_release == 'jessie' %}
-# Extended Long Term Support (ELTS, until 2025-06-30, see https://wiki.debian.org/LTS/Extended)
+# WARN: Extended Long Term Support - EOL since 2025-06-30 (see https://wiki.debian.org/LTS/Extended)
 deb https://deb.freexian.com/extended-lts jessie-lts main contrib non-free
 {% elif ansible_distribution_release == 'stretch' %}
 # Extended Long Term Support (ELTS, until 2027-06-30, see https://wiki.debian.org/LTS/Extended)


### PR DESCRIPTION
* bullseye-backports was moved to archive
* buster/updates was moved to archive
* update release support information for jessie