### PR TITLE
Debian: add support for trixie-updates repository

### DIFF
--- a/templates/apt/sources.list.j2
+++ b/templates/apt/sources.list.j2
@@ -68,6 +68,8 @@ deb {{ base_debian_mirror }} bullseye-updates main contrib non-free
 {% elif ansible_distribution_release == 'bookworm' %}
 # NOTE: supported until 2026-06-10 (main), 2028-06-30 (LTS) + 2033-06-30 (ELTS)
 deb {{ base_debian_mirror }} bookworm-updates main contrib non-free-firmware
+{% else %}
+deb {{ base_debian_mirror }} {{ ansible_distribution_release }}-updates main contrib non-free-firmware
 {% endif %}{# ansible_distribution_release == 'bullseye' #}
 {% endif %}{# base_enable_stable_updates #}
 {% if base_enable_elts %}


### PR DESCRIPTION
We usually hardcode the release name, to provide according support information in the related notes. Because we didn't explicitly check for trixie so far (which will be released as new Debian stable release as of 2025-08-09), the trixie-updates repository was not yet available (even if base_enable_stable_updates is enabled).
    
Since there's no official support information available for trixie yet. Use the generic ${ansible_distribution_release}-updates, to avoid ending up without an *-updates entry. Once the support information for trixie will be available, we can add an explicit check for "trixie".
