### PR TITLE
Make sure /etc/apt/debian.sources is absent

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,8 +28,9 @@ galaxy_info:
   platforms:
     - name: "Debian"
       versions:
-        - 10
         - 11
+        - 12
+        - 13
 
   galaxy_tags: []
   # List tags for your role here, one per line. A tag is a keyword that describes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,10 +16,17 @@
     - base_enable_elts is defined
     - base_enable_elts == true
     - ansible_distribution_release == "wheezy" or ansible_distribution_release == "jessie" or ansible_distribution_release == "stretch" or ansible_distribution_release == "buster"
+
+- name: Make sure /etc/apt/debian.sources is absent
+  file:
+    path: /etc/apt/debian.sources
+    state: absent
+
 - name: Provide /etc/apt/sources.list
   template: src=templates/apt/sources.list.j2 dest=/etc/apt/sources.list owner=root group=root mode=0644
   notify: apt-get update
   when: ansible_distribution == 'Debian'
+
 - meta: flush_handlers
 
 - name: Ensure base Debian package selection is installed


### PR DESCRIPTION
Debian/trixie systems deploy deb822-style format APT repository sources.
This role currently does support and expect anything else then the
classic one-line-style format.

Until deb822-style format support is added we need to make sure that the
/etc/apt/debian.sources is absent.

Issue: https://github.com/jkirk/ansible-role-base/issues/29

/cc @mika 