### PR TITLE
Make really sure deb822-style apt + mirror files are absent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,14 +17,14 @@
     - base_enable_elts == true
     - ansible_distribution_release == "wheezy" or ansible_distribution_release == "jessie" or ansible_distribution_release == "stretch" or ansible_distribution_release == "buster"
 
-- name: Make sure deb822-style apt + mirror files are are absent
+- name: Make sure deb822-style apt + mirror files are absent
   ansible.builtin.file:
-    path:
-      - /etc/apt/debian.sources
-      - /etc/apt/sources.list.d/debian.sources
-      - /etc/apt/mirrors/debian.list
-      - /etc/apt/mirrors/debian-security.list
+    path: "{{ item }}"
     state: absent
+  loop:
+    - /etc/apt/mirrors/debian.list
+    - /etc/apt/mirrors/debian-security.list
+    - /etc/apt/sources.list.d/debian.sources
 
 - name: Provide /etc/apt/sources.list
   template: src=templates/apt/sources.list.j2 dest=/etc/apt/sources.list owner=root group=root mode=0644


### PR DESCRIPTION
Fixup of 2dca999: I used the wrong syntax to remove multiple files.

Debian/trixie systems deploy deb822-style format APT repository sources. This role currently does support only the classic one-line-style format.

Until deb822-style format support is added we need to make sure that the /etc/apt/debian.sources + /etc/apt/sources.list.d/debian.sources are absent.

We also remove apt mirror files which are referenced in /etc/apt/sources.list.d/debian.sources.

(This is follow up to commits a23f50d + 2dca999).

Issue: jkirk/ansible-role-base#29

@mika Please review. Especially I am not sure about removing the apt mirror files.